### PR TITLE
parse screenshot invocation event type

### DIFF
--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativePackage.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativePackage.java
@@ -78,6 +78,9 @@ public class RNInstabugReactnativePackage implements ReactPackage {
             } else if (invocationEventValues[i].equals("shake")) {
                 this.invocationEvents.add(InstabugInvocationEvent.SHAKE);
 
+            } else if (invocationEventValues[i].equals("screenshot")) {
+                this.invocationEvents.add(InstabugInvocationEvent.SCREENSHOT);
+
             } else if (invocationEventValues[i].equals("none")) {
                 this.invocationEvents.add(InstabugInvocationEvent.NONE);
             }


### PR DESCRIPTION
The Android implementation is missing a branch in the `parseInvocationEvent` loop for the `InstabugInvocationEvent.SCREENSHOT` type. It prevents users from using the screenshot invocation on Android React Native apps.